### PR TITLE
URL Spark Change

### DIFF
--- a/build/docker/spark-base/Dockerfile
+++ b/build/docker/spark-base/Dockerfile
@@ -16,7 +16,7 @@ LABEL org.label-schema.schema-version="1.0"
 ARG spark_version
 ARG hadoop_version
 
-RUN curl https://archive.apache.org/dist/spark/spark-${spark_version}/spark-${spark_version}-bin-hadoop${hadoop_version}.tgz -o spark.tgz && \
+RUN curl https://dlcdn.apache.org/spark/spark-${spark_version}/spark-${spark_version}-bin-hadoop${hadoop_version}.tgz -o spark.tgz && \
     tar -xf spark.tgz && \
     mv spark-${spark_version}-bin-hadoop${hadoop_version} /usr/bin/ && \
     echo "alias pyspark=/usr/bin/spark-${spark_version}-bin-hadoop${hadoop_version}/bin/pyspark" >> ~/.bashrc && \


### PR DESCRIPTION
The URL to download Apache Spark has changed.

## Introduction
This PR is to fix the URL format since the download URL for Apache Spark has change the structure.

## Pull Request

### Issue

https://github.com/cluster-apps-on-docker/spark-standalone-cluster-on-docker/issues/81#issue-1070782920

### Changes

- On the spark-base Dockerfile update the URL in the *curl* command to retrieve the Apache Spark package.
